### PR TITLE
Fix navigation bar color for dark theme

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -30,6 +30,11 @@
 
         <item name="windowActionModeOverlay">true</item>
         <item name="popupMenuBackground">@drawable/rounded</item>
+
+        <item name="android:navigationBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:windowTranslucentNavigation">true</item>
     </style>
 
     <style name="ThemeOverlay.App.MaterialAlertDialog.Monet" parent="ThemeOverlay.Material3.MaterialAlertDialog">

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -31,10 +31,7 @@
         <item name="windowActionModeOverlay">true</item>
         <item name="popupMenuBackground">@drawable/rounded</item>
 
-        <item name="android:navigationBarColor">
-            @android:color/transparent
-        </item>
-        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
     <style name="ThemeOverlay.App.MaterialAlertDialog.Monet" parent="ThemeOverlay.Material3.MaterialAlertDialog">


### PR DESCRIPTION
These lines seem to fix https://github.com/ziadOUA/zCard/issues/16 for me. I just realized the problem occurs only on my Android 10 device. It was black all the time for Android 13.. But this seems to work well and makes the navigation bar look the same for both versions now in dark/black theme. Cheers!